### PR TITLE
To use semicolons or not, that's the question

### DIFF
--- a/build.js
+++ b/build.js
@@ -71,7 +71,7 @@ exports.renderJade = function(){
       // Generate automatic page links
       locals.page_link = function(name){
        
-        var page = data.templates.filter(function(t){return t.name === name});
+        var page = data.templates.filter(function(t){return t.name === name;});
         page = page[0].languages[lang];
             
         if (name != 'index' && data.default_language != lang){
@@ -108,7 +108,7 @@ exports.renderJade = function(){
 
   });
 
-}
+};
 
 // Render Sass
 exports.renderSass = function(){
@@ -139,4 +139,4 @@ exports.renderSass = function(){
     }
   });
   
-}
+};

--- a/generator.js
+++ b/generator.js
@@ -5,6 +5,6 @@ var build = require('./build.js');
 
 // Render
 build.renderJade();
-console.log('Build succeeded for Jade templates...'.green)
-build.renderSass()
-console.log('Build succeeded for SASS templates...'.green)
+console.log('Build succeeded for Jade templates...'.green);
+build.renderSass();
+console.log('Build succeeded for SASS templates...'.green);

--- a/watch.js
+++ b/watch.js
@@ -9,9 +9,9 @@ var data = require('./config.json');
 
 // Render for the first time before watching
 build.renderJade();
-console.log('Build succeeded for Jade templates...'.green)
-build.renderSass()
-console.log('Build succeeded for SASS templates...'.green)
+console.log('Build succeeded for Jade templates...'.green);
+build.renderSass();
+console.log('Build succeeded for SASS templates...'.green);
 
 // Watcher
 function watcher(type, fn){


### PR DESCRIPTION
Running the command
`$ eslint *.js --rule ""semi": [2, "always"]" --no-eslintrc`

gives you 

```
.../ztat/watch.js
  12:59  error  Missing semicolon  semi
  13:19  error  Missing semicolon  semi
  14:59  error  Missing semicolon  semi

.../ztat/build.js
   74:76  error  Missing semicolon  semi
  111:2   error  Missing semicolon  semi
  142:2   error  Missing semicolon  semi

.../ztat/generator.js
   8:59  error  Missing semicolon  semi
   9:19  error  Missing semicolon  semi
  10:59  error  Missing semicolon  semi
```

The fix is quite straightforward, adding the flag `--fix` to the mentioned command will do the work for you. The underlying question of using semicolons or not may be a different discussion.

Take a look at [node-tooling](https://github.com/a0viedo/node-tooling) for similar tooling options.
